### PR TITLE
Implement equal?/2

### DIFF
--- a/lib/ecto/atomized_map.ex
+++ b/lib/ecto/atomized_map.ex
@@ -12,9 +12,14 @@ defmodule Ecto.AtomizedMap do
   def dump(map) when is_map(map), do: {:ok, map}
   def dump(_term), do: :error
 
+  def equal?(term1, term2) when is_map(term1) and is_map(term2),
+    do: atomize(term1) == atomize(term2)
+
+  def equal?(nil, nil), do: true
+
+  def equal?(_term1, _term2), do: false
 
   defp atomize(map) do
     ExUtils.Map.symbolize_keys(map)
   end
-
 end


### PR DESCRIPTION
This change is needed to make `AtomizedMap` work with Ecto >= 3.5.0.
Specifically, [this commit](https://github.com/elixir-ecto/ecto/commit/b04bbf25d6b6998ef7fddd18e547950edd34eead) changes the way `equal?/2` is called.